### PR TITLE
機能①：今夜の肴（ランダム出題 + 入力フォーム）

### DIFF
--- a/app/controllers/prescriptions_controller.rb
+++ b/app/controllers/prescriptions_controller.rb
@@ -1,0 +1,12 @@
+class PrescriptionsController < ApplicationController
+  def create
+    # Claude API連携は issue #4 で実装
+    @topic = Topic.find(params[:topic_id])
+    @answer = params[:answer]
+    redirect_to prescription_path("preview")
+  end
+
+  def show
+    # Claude API連携は issue #4 で実装
+  end
+end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,0 +1,5 @@
+class TopicsController < ApplicationController
+  def show
+    @topic = Topic.order("RANDOM()").first
+  end
+end

--- a/app/views/prescriptions/show.html.erb
+++ b/app/views/prescriptions/show.html.erb
@@ -1,0 +1,3 @@
+<div class="prescription-container">
+  <p>服薬指導箋（Claude API連携は issue #4 で実装予定）</p>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,0 +1,21 @@
+<div class="topic-container">
+  <% if @topic %>
+    <section class="topic-card">
+      <p class="topic-category"><%= @topic.category %></p>
+      <h1 class="topic-name"><%= @topic.name %></h1>
+      <p class="topic-rule"><%= @topic.rule %></p>
+      <p class="topic-question"><%= @topic.question %></p>
+    </section>
+
+    <%= form_with url: prescriptions_path, method: :post do |f| %>
+      <%= f.hidden_field :topic_id, value: @topic.id %>
+      <div class="input-section">
+        <%= f.label :answer, "あなたの答えを書いてください" %>
+        <%= f.text_area :answer, placeholder: "思ったことを自由に...", rows: 6 %>
+      </div>
+      <%= f.submit "服薬指導箋を生成する" %>
+    <% end %>
+  <% else %>
+    <p>お題がまだ登録されていません。</p>
+  <% end %>
+</div>

--- a/docs/scrap/feature-todays-topic.md
+++ b/docs/scrap/feature-todays-topic.md
@@ -1,0 +1,26 @@
+# 今夜の肴（ランダム出題 + 入力フォーム）
+
+## やったこと
+
+- `TopicsController#show` でランダムにお題を1件取得
+- お題表示ビュー（カテゴリ・名前・ルール・問いの構造）
+- 自由入力フォームを作成し、`PrescriptionsController#create` へ POST
+- `PrescriptionsController` は issue #4 で Claude API 連携するためスタブのみ実装
+
+## 学んだこと
+
+### RANDOM() でランダム取得
+```ruby
+Topic.order("RANDOM()").first
+```
+PostgreSQL では `ORDER BY RANDOM()` でランダムソート。小規模データならこれで十分。
+大規模になると全件ソートになるので、その場合は `OFFSET` + `COUNT` の方が効率的。
+
+### form_with の hidden_field でお題IDを引き回す
+フォーム送信時にどのお題に対する回答かを識別するため、`hidden_field` で `topic_id` を埋め込む。
+`prescriptions#create` で `params[:topic_id]` として受け取る。
+
+### ルーティング設計
+- `root "topics#show"` → トップページがそのままお題表示
+- `resources :prescriptions, only: [:create, :show]` → 送信先と結果表示のみ
+- シンプルな一方向フローになっている


### PR DESCRIPTION
## 概要

Issue #3 の実装。お題をランダム表示し、自由入力フォームで回答を受け付ける画面。

## 変更内容

- `TopicsController#show`: `ORDER BY RANDOM()` でお題を1件取得
- `app/views/topics/show.html.erb`: カテゴリ・名前・ルール・問いの構造で表示 + 自由入力フォーム
- `PrescriptionsController`: issue #4（Claude API連携）のためのスタブ実装
- `docs/scrap/feature-todays-topic.md`: 学習メモ

## 動作確認

- `Topic.count` → 21件確認済み
- `Topic.order("RANDOM()").first` → ランダム取得動作確認済み
- ルーティング: `root → topics#show`、フォーム → `POST /prescriptions`

## 関連

- Closes #3
- 次: #4（Claude API連携で服薬指導箋を生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)