### PR TITLE
feat: 服薬指導箋 AI 生成（Claude API連携）

### DIFF
--- a/app/controllers/prescriptions_controller.rb
+++ b/app/controllers/prescriptions_controller.rb
@@ -1,12 +1,26 @@
 class PrescriptionsController < ApplicationController
   def create
-    # Claude API連携は issue #4 で実装
-    @topic = Topic.find(params[:topic_id])
-    @answer = params[:answer]
-    redirect_to prescription_path("preview")
+    topic = Topic.find(params[:topic_id])
+    user_input = params[:answer].to_s.strip
+
+    if user_input.blank?
+      redirect_to root_path, alert: "回答を入力してください"
+      return
+    end
+
+    ai_response = ClaudeService.new.generate_prescription(topic: topic, user_input: user_input)
+
+    prescription = Prescription.create!(
+      topic: topic,
+      user_input: user_input,
+      ai_response: ai_response
+    )
+
+    redirect_to prescription_path(prescription)
   end
 
   def show
-    # Claude API連携は issue #4 で実装
+    @prescription = Prescription.find(params[:id])
+    @topic = @prescription.topic
   end
 end

--- a/app/models/prescription.rb
+++ b/app/models/prescription.rb
@@ -1,0 +1,5 @@
+class Prescription < ApplicationRecord
+  belongs_to :topic
+
+  validates :user_input, presence: true
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -5,4 +5,6 @@ class Topic < ApplicationRecord
   validates :category, presence: true
 
   CATEGORIES = %w[数学 物理 生物 コンピューターサイエンス 食の科学 建築 歴史・文献 言語 行動・社会].freeze
+
+  has_many :prescriptions
 end

--- a/app/services/claude_service.rb
+++ b/app/services/claude_service.rb
@@ -1,0 +1,52 @@
+class ClaudeService
+  SYSTEM_PROMPT = <<~PROMPT
+    あなたは「柴犬薬剤師」です。
+    ユーザーが知識のお題に答えると、その内容を分析し、服薬指導箋の形式で返答します。
+
+    ## 架空の薬の命名ルール
+    薬名は以下の3要素を組み合わせて作ります：
+    1. 回答の本質（何について答えているか）
+    2. 作用（どんな効果をもたらすか）
+    3. 剤形（カプセル剤、錠剤、散剤、液剤、吸入剤など）
+
+    例：光合成について正確に答えた場合 → 「光子吸収活性化カプセル」
+    例：水の性質について答えた場合 → 「分子間引力促進液剤」
+
+    ## 返答フォーマット
+    必ず以下のフォーマットのみで返答してください。前置きや後書きは不要です。
+
+    【服薬指導箋】
+
+    薬剤名：（架空の薬名）
+    分類：（薬の分類カテゴリ）
+    用法・用量：（1日○回、○錠など具体的に）
+    効能・効果：（この知識を「服用」することでどんな効果が得られるか）
+    副作用：（この知識を知ることの思わぬ「副作用」をユーモラスに1〜2つ）
+    薬剤師より：（柴犬薬剤師らしい温かみのあるひと言。ユーモアと知識愛にあふれた口調で）
+
+    ユーザーの回答が正確であれば効き目の強い薬を、あいまいであれば補助薬や予防薬として処方してください。
+    いずれの場合も温かく前向きなトーンを保ってください。
+  PROMPT
+
+  def initialize
+    @client = Anthropic::Client.new(api_key: ENV["CLAUDE_API_KEY"])
+  end
+
+  def generate_prescription(topic:, user_input:)
+    prompt = <<~PROMPT
+      お題：#{topic.name}
+      ルール：#{topic.rule}
+      問い：#{topic.question}
+      ユーザーの回答：#{user_input}
+    PROMPT
+
+    response = @client.messages.create(
+      model: :"claude-haiku-4-5-20251001",
+      max_tokens: 4096,
+      system_: [{ type: "text", text: SYSTEM_PROMPT }],
+      messages: [{ role: "user", content: prompt }]
+    )
+
+    response.content.find { |block| block.type == :text }&.text
+  end
+end

--- a/app/views/prescriptions/show.html.erb
+++ b/app/views/prescriptions/show.html.erb
@@ -1,3 +1,21 @@
 <div class="prescription-container">
-  <p>服薬指導箋（Claude API連携は issue #4 で実装予定）</p>
+  <section class="original-topic">
+    <p class="topic-category"><%= @topic.category %></p>
+    <h2 class="topic-name"><%= @topic.name %></h2>
+    <p class="topic-question"><%= @topic.question %></p>
+    <div class="user-answer">
+      <p class="answer-label">あなたの答え</p>
+      <p class="answer-text"><%= @prescription.user_input %></p>
+    </div>
+  </section>
+
+  <section class="prescription-card">
+    <div class="prescription-text">
+      <%= simple_format(@prescription.ai_response) %>
+    </div>
+  </section>
+
+  <div class="prescription-actions">
+    <%= link_to "もう一度やってみる", root_path, class: "btn-retry" %>
+  </div>
 </div>

--- a/db/migrate/20260502165338_create_prescriptions.rb
+++ b/db/migrate/20260502165338_create_prescriptions.rb
@@ -1,0 +1,11 @@
+class CreatePrescriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :prescriptions, id: :uuid do |t|
+      t.integer :topic_id, null: false
+      t.text :user_input, null: false
+      t.text :ai_response
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_02_163137) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_02_165338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -32,6 +32,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_02_163137) do
   create_enum "oauth_registration_type", ["dynamic", "manual"]
   create_enum "oauth_response_type", ["code"]
   create_enum "one_time_token_type", ["confirmation_token", "reauthentication_token", "recovery_token", "email_change_token_new", "email_change_token_current", "phone_change_token"]
+
+  create_table "prescriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "topic_id", null: false
+    t.text "user_input", null: false
+    t.text "ai_response"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "topics", force: :cascade do |t|
     t.string "name"

--- a/docs/scrap/feature-prescription-ai.md
+++ b/docs/scrap/feature-prescription-ai.md
@@ -1,0 +1,47 @@
+# 服薬指導箋 AI 生成（Claude API 連携）
+
+## やったこと
+
+- `prescriptions` テーブルのマイグレーション（UUID PK、topic_id、user_input、ai_response）
+- `ClaudeService` を `app/services/` に実装（柴犬薬剤師キャラ + 服薬指導箋フォーマット）
+- `PrescriptionsController#create` で ClaudeService を呼び、DB に保存して `show` へリダイレクト
+- `prescriptions#show` ビューで服薬指導箋を表示
+
+## 学んだこと
+
+### Rails の Service Object パターン
+`app/services/` にビジネスロジックを分離すると、コントローラーが薄くなり責務が明確になる。
+Rails はデフォルトで `app/services/` を autoload してくれる（Rails 6以降）。
+
+### Anthropic Ruby SDK の使い方
+```ruby
+client = Anthropic::Client.new(api_key: ENV["CLAUDE_API_KEY"])
+response = client.messages.create(
+  model: :"claude-haiku-4-5-20251001",
+  max_tokens: 4096,
+  system_: [{ type: "text", text: SYSTEM_PROMPT }],
+  messages: [{ role: "user", content: prompt }]
+)
+text = response.content.find { |block| block.type == :text }&.text
+```
+
+- `system_` はアンダースコア付き（`Kernel#system` との衝突を避けるため）
+- `response.content` は配列なので `type == :text` のブロックを探す
+- `.type` はシンボル（`:text`）で比較する
+
+### UUID を PK にするマイグレーション
+```ruby
+create_table :prescriptions, id: :uuid do |t|
+  ...
+end
+```
+Supabase と相性が良く、外部公開URLに連番IDを使わずに済む。
+
+### システムプロンプト設計のポイント
+- キャラクター定義・フォーマット・架空の薬の命名ルールを明示すると出力が安定する
+- フォーマットを厳密に指定し「前置き不要」と書くことで余計なテキストを減らせる
+- ユーザー回答の質（正確 or あいまい）に応じた処方を促すと評価フィードバックになる
+
+### `.env` の重複問題
+`CLAUDE_API_KEY` が2重に書かれており認証エラーになっていた。
+`rails runner "puts ENV['CLAUDE_API_KEY'].length"` で文字数を確認し発見。


### PR DESCRIPTION
## Summary

- `prescriptions` テーブル作成（UUID PK, topic_id, user_input, ai_response）
- `ClaudeService` 実装：柴犬薬剤師キャラ＋架空の薬名ルール＋服薬指導箋フォーマットのシステムプロンプト
- `PrescriptionsController` 実装：ClaudeService を呼び、DB 保存、`show` へリダイレクト
- `prescriptions#show` ビュー：お題・ユーザー回答・AI生成服薬指導箋を表示
- `.env` の `CLAUDE_API_KEY` 重複を修正

Closes #4

## Test plan

- [x] トップページでお題が表示される
- [x] 回答を入力して「服薬指導箋を生成する」を押すと `/prescriptions/:id` にリダイレクトされる
- [x] 服薬指導箋（薬剤名・分類・用法・効能・副作用・薬剤師より）が表示される
- [x] DB の `prescriptions` テーブルにレコードが保存されている
- [x] 空の回答を送るとトップページにリダイレクトされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)