### PR TITLE
機能②：今日の副作用レポート

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,12 @@
  *= require_tree .
  *= require_self
  */
+
+.flash-alert {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  padding: 12px 16px;
+  text-align: center;
+  font-size: 14px;
+}

--- a/app/controllers/side_effect_reports_controller.rb
+++ b/app/controllers/side_effect_reports_controller.rb
@@ -1,0 +1,5 @@
+class SideEffectReportsController < ApplicationController
+  def show
+    @report = SideEffectReport.find(params[:id])
+  end
+end

--- a/app/controllers/side_effects_controller.rb
+++ b/app/controllers/side_effects_controller.rb
@@ -1,0 +1,22 @@
+class SideEffectsController < ApplicationController
+  def new
+  end
+
+  def create
+    user_input = params[:user_input].to_s.strip
+
+    if user_input.blank?
+      redirect_to new_side_effect_path, alert: "今日やったことを入力してください"
+      return
+    end
+
+    ai_response = ClaudeService.new.generate_side_effect_report(user_input: user_input)
+
+    report = SideEffectReport.create!(
+      user_input: user_input,
+      ai_response: ai_response
+    )
+
+    redirect_to side_effect_report_path(report)
+  end
+end

--- a/app/models/side_effect_report.rb
+++ b/app/models/side_effect_report.rb
@@ -1,0 +1,3 @@
+class SideEffectReport < ApplicationRecord
+  validates :user_input, presence: true
+end

--- a/app/services/claude_service.rb
+++ b/app/services/claude_service.rb
@@ -28,8 +28,43 @@ class ClaudeService
     いずれの場合も温かく前向きなトーンを保ってください。
   PROMPT
 
+  SIDE_EFFECT_SYSTEM_PROMPT = <<~PROMPT
+    あなたは「柴犬薬剤師」です。
+    ユーザーが今日やったことを入力すると、それを「今日の活動成分」として分析し、添付文書形式で返答します。
+
+    ## キャラクターの口調
+    - 話しかけるような自然な口調（「〜ですね」「〜ですよ〜」など）
+    - 共感ベースで、説教っぽくならないように
+    - テンションは「忙しい薬局の休憩中に話しかけてくる先輩」くらい
+
+    ## 今夜の処方（酒）の選び方
+    今日の活動内容・気分・疲労感に合わせて、実在するお酒を1種類処方してください。
+    形式：「（酒名） ○ml、就寝前1回」のように具体的に。
+
+    ## 返答フォーマット
+    必ず以下のフォーマットのみで返答してください。前置きや後書きは不要です。
+
+    【今日の副作用レポート】
+
+    今日の活動成分：（今日やったことを簡潔に1行で表現）
+    効能・効果：（今日の活動で得られた能力・成長をポジティブに1〜2行）
+    副作用：（今日の活動の思わぬ「副作用」をユーモラスに1〜2つ）
+    今夜の処方：（お酒の種類・量・タイミング。柴犬薬剤師らしい処方コメントも添えて）
+  PROMPT
+
   def initialize
     @client = Anthropic::Client.new(api_key: ENV["CLAUDE_API_KEY"])
+  end
+
+  def generate_side_effect_report(user_input:)
+    response = @client.messages.create(
+      model: :"claude-haiku-4-5-20251001",
+      max_tokens: 1024,
+      system_: [{ type: "text", text: SIDE_EFFECT_SYSTEM_PROMPT }],
+      messages: [{ role: "user", content: "今日やったこと：#{user_input}" }]
+    )
+
+    response.content.find { |block| block.type == :text }&.text
   end
 
   def generate_prescription(topic:, user_input:)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+    <% if flash[:alert] %>
+      <div class="flash-alert"><%= flash[:alert] %></div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/side_effect_reports/show.html.erb
+++ b/app/views/side_effect_reports/show.html.erb
@@ -1,0 +1,20 @@
+<div class="prescription-container">
+  <section class="original-topic">
+    <p class="topic-category">今日の副作用レポート</p>
+    <div class="user-answer">
+      <p class="answer-label">今日やったこと</p>
+      <p class="answer-text"><%= @report.user_input %></p>
+    </div>
+  </section>
+
+  <section class="prescription-card">
+    <div class="prescription-text">
+      <%= simple_format(@report.ai_response) %>
+    </div>
+  </section>
+
+  <div class="prescription-actions">
+    <%= link_to "もう一度レポートを書く", new_side_effect_path, class: "btn-retry" %>
+    <%= link_to "今日のお題へ", root_path, class: "btn-retry" %>
+  </div>
+</div>

--- a/app/views/side_effects/new.html.erb
+++ b/app/views/side_effects/new.html.erb
@@ -1,0 +1,15 @@
+<div class="topic-container">
+  <section class="topic-card">
+    <p class="topic-category">今日の副作用レポート</p>
+    <h1 class="topic-name">今日、何してた？</h1>
+    <p class="topic-rule">今日やったこと・起きたこと・感じたことを自由に書いてください。柴犬薬剤師が副作用レポートを発行します。</p>
+  </section>
+
+  <%= form_with url: side_effects_path, method: :post do |f| %>
+    <div class="input-section">
+      <%= f.label :user_input, "今日やったこと" %>
+      <%= f.text_area :user_input, placeholder: "例：Railsのgemバージョンで3時間溶けた", rows: 6 %>
+    </div>
+    <%= f.submit "副作用レポートを発行する" %>
+  <% end %>
+</div>

--- a/db/migrate/20260502173651_create_side_effect_reports.rb
+++ b/db/migrate/20260502173651_create_side_effect_reports.rb
@@ -1,0 +1,10 @@
+class CreateSideEffectReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :side_effect_reports, id: :uuid do |t|
+      t.text :user_input, null: false
+      t.text :ai_response
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_02_165338) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_02_173651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -35,6 +35,13 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_02_165338) do
 
   create_table "prescriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "topic_id", null: false
+    t.text "user_input", null: false
+    t.text "ai_response"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "side_effect_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "user_input", null: false
     t.text "ai_response"
     t.datetime "created_at", null: false

--- a/docs/scrap/feature-side-effect-report.md
+++ b/docs/scrap/feature-side-effect-report.md
@@ -1,0 +1,24 @@
+# 今日の副作用レポート実装メモ（issue #5）
+
+## 追加したもの
+
+- `SideEffectReport` モデル・マイグレーション（UUID PK）
+- `SideEffectsController`（new / create）
+- `SideEffectReportsController`（show）
+- `ClaudeService#generate_side_effect_report`（専用プロンプト）
+- ビュー2枚：入力フォーム・結果表示
+
+## ClaudeService の設計メモ
+
+`SIDE_EFFECT_SYSTEM_PROMPT` を既存の `SYSTEM_PROMPT` とは別定数で定義。
+服薬指導箋とは別の世界観（添付文書風）なので、プロンプトを混ぜないほうがトーンが安定しやすい。
+
+出力フォーマット：
+- 今日の活動成分
+- 効能・効果
+- 副作用
+- 今夜の処方（実在するお酒を具体的に）
+
+## ルーティング
+
+既に `config/routes.rb` に記載済みだったのでそのまま流用。


### PR DESCRIPTION
closes #5

## Summary
- 今日やったことを入力すると、柴犬薬剤師が「効能・効果 / 副作用 / 今夜の処方（酒）」を生成する機能を追加
- `SideEffectReport` モデル（UUID PK）・マイグレーション追加
- `ClaudeService` に専用プロンプト `SIDE_EFFECT_SYSTEM_PROMPT` と `generate_side_effect_report` メソッドを追加
- 入力フォーム（`/side_effects/new`）・結果表示（`/side_effect_reports/:id`）を実装

## Test plan
- [x] `/side_effects/new` にアクセスしてフォームが表示されることを確認
- [x] 今日やったことを入力して送信 → レポートが生成・表示されることを確認
- [x] 空送信でバリデーションが効くことを確認
- [x] 今夜の処方（酒）が具体的に出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)