### PR TITLE
Add share buttons and OGP meta tags (#7)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -684,3 +684,31 @@ input[type="submit"]:hover {
   border-color: var(--accent);
   color: var(--accent);
 }
+
+.btn-share-x {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 20px;
+  background: #000;
+  border: 1px solid #333;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #fff;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-share-x:hover {
+  background: #1a1a1a;
+  border-color: #555;
+  color: #fff;
+}
+
+.x-icon {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+  flex-shrink: 0;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -712,3 +712,30 @@ input[type="submit"]:hover {
   fill: currentColor;
   flex-shrink: 0;
 }
+
+.btn-share-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 20px;
+  background: #06C755;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #fff;
+  transition: background 0.15s;
+}
+
+.btn-share-line:hover {
+  background: #05b34b;
+  color: #fff;
+}
+
+.line-icon {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+  flex-shrink: 0;
+}

--- a/app/controllers/prescriptions_controller.rb
+++ b/app/controllers/prescriptions_controller.rb
@@ -22,5 +22,7 @@ class PrescriptionsController < ApplicationController
   def show
     @prescription = Prescription.find(params[:id])
     @topic = @prescription.topic
+    @og_title = "「#{@topic.name}」への服薬指導箋"
+    @og_description = @prescription.ai_response.truncate(100)
   end
 end

--- a/app/controllers/side_effect_reports_controller.rb
+++ b/app/controllers/side_effect_reports_controller.rb
@@ -1,5 +1,7 @@
 class SideEffectReportsController < ApplicationController
   def show
     @report = SideEffectReport.find(params[:id])
+    @og_title = "副作用レポート"
+    @og_description = @report.ai_response.truncate(100)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,18 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <title>PharmacyBar</title>
+    <title><%= @og_title.present? ? "#{@og_title} | 深夜薬局 Bar" : "深夜薬局 Bar" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <meta property="og:site_name" content="深夜薬局 Bar">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="<%= @og_title.present? ? "#{@og_title} | 深夜薬局 Bar" : "深夜薬局 Bar" %>">
+    <meta property="og:description" content="<%= @og_description.present? ? @og_description : "知的好奇心に、薬を。深夜の薬剤師があなたのアイデアに服薬指導箋を発行します。" %>">
+    <meta property="og:image" content="<%= "#{request.base_url}/ogp.png" %>">
+    <meta property="og:url" content="<%= request.url %>">
+    <meta name="twitter:card" content="summary_large_image">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/app/views/prescriptions/show.html.erb
+++ b/app/views/prescriptions/show.html.erb
@@ -16,6 +16,11 @@
   </section>
 
   <div class="prescription-actions">
+    <% tweet_text = "「#{@topic.name}」への服薬指導箋を受け取りました。 #深夜薬局Bar" %>
+    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(request.url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
+      <svg viewBox="0 0 24 24" aria-hidden="true" class="x-icon"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      Xでシェア
+    <% end %>
     <%= link_to "もう一度やってみる", play_path, class: "btn-retry" %>
     <%= link_to "今日の副作用レポートを書く", new_side_effect_path, class: "btn-retry" %>
   </div>

--- a/app/views/prescriptions/show.html.erb
+++ b/app/views/prescriptions/show.html.erb
@@ -16,10 +16,14 @@
   </section>
 
   <div class="prescription-actions">
-    <% tweet_text = "「#{@topic.name}」への服薬指導箋を受け取りました。 #深夜薬局Bar" %>
-    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(request.url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
+    <% tweet_text = "「#{@topic.name}」について柴犬薬剤師に相談してみた #Pharmacy_Bar" %>
+    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(root_url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
       <svg viewBox="0 0 24 24" aria-hidden="true" class="x-icon"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
       Xでシェア
+    <% end %>
+    <%= link_to "https://social-plugins.line.me/lineit/share?url=#{ERB::Util.url_encode(root_url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-line" do %>
+      <svg viewBox="0 0 24 24" aria-hidden="true" class="line-icon"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.281.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+      LINEでシェア
     <% end %>
     <%= link_to "もう一度やってみる", play_path, class: "btn-retry" %>
     <%= link_to "今日の副作用レポートを書く", new_side_effect_path, class: "btn-retry" %>

--- a/app/views/side_effect_reports/show.html.erb
+++ b/app/views/side_effect_reports/show.html.erb
@@ -14,6 +14,11 @@
   </section>
 
   <div class="prescription-actions">
+    <% tweet_text = "副作用レポートを書きました。 #深夜薬局Bar" %>
+    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(request.url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
+      <svg viewBox="0 0 24 24" aria-hidden="true" class="x-icon"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      Xでシェア
+    <% end %>
     <%= link_to "もう一度レポートを書く", new_side_effect_path, class: "btn-retry" %>
     <%= link_to "今日のお題へ", play_path, class: "btn-retry" %>
   </div>

--- a/app/views/side_effect_reports/show.html.erb
+++ b/app/views/side_effect_reports/show.html.erb
@@ -14,10 +14,14 @@
   </section>
 
   <div class="prescription-actions">
-    <% tweet_text = "副作用レポートを書きました。 #深夜薬局Bar" %>
-    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(request.url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
+    <% tweet_text = "今日のことを柴犬薬剤師に相談したら副作用レポートが届いた #Pharmacy_Bar" %>
+    <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(tweet_text)}&url=#{ERB::Util.url_encode(root_url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
       <svg viewBox="0 0 24 24" aria-hidden="true" class="x-icon"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
       Xでシェア
+    <% end %>
+    <%= link_to "https://social-plugins.line.me/lineit/share?url=#{ERB::Util.url_encode(root_url)}", target: "_blank", rel: "noopener noreferrer", class: "btn-share-line" do %>
+      <svg viewBox="0 0 24 24" aria-hidden="true" class="line-icon"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.630 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.281.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+      LINEでシェア
     <% end %>
     <%= link_to "もう一度レポートを書く", new_side_effect_path, class: "btn-retry" %>
     <%= link_to "今日のお題へ", play_path, class: "btn-retry" %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Default URL options for URL helpers (used in rake tasks, console, etc.)
+  routes.default_url_options = { host: "deep-night-pharmacy-bar.onrender.com", protocol: "https" }
 end

--- a/docs/scrap/feature-share.md
+++ b/docs/scrap/feature-share.md
@@ -1,0 +1,36 @@
+# シェア機能（Xシェア + 静的OGP）
+
+## 実装内容
+
+### Xシェアボタン
+- 服薬指導箋・副作用レポートの結果ページ末尾に「Xでシェア」ボタンを追加
+- `https://twitter.com/intent/tweet?text=...&url=...` 形式のリンク
+- テキストは `ERB::Util.url_encode` でエンコード（XSS対策・文字化け防止）
+
+### OGPメタタグ
+- `application.html.erb` の `<head>` に共通OGPタグを配置
+- `og:title` / `og:description` はコントローラのインスタンス変数で動的に差し込む
+
+| ページ | og:title | og:description |
+|---|---|---|
+| 服薬指導箋 | 「{topic.name}」への服薬指導箋 | ai_response の冒頭100文字 |
+| 副作用レポート | 副作用レポート | ai_response の冒頭100文字 |
+| その他 | 深夜薬局 Bar | デフォルト説明文 |
+
+- `og:image` → 静的画像 `/ogp.png`（`public/ogp.png` に配置が必要）
+- `og:url` → `request.url`（Rails の request オブジェクトから取得）
+- `twitter:card` → `summary_large_image`
+
+### OGP画像
+- `public/ogp.png` を手動で用意する必要がある
+- Twitter/X 推奨サイズ: 1200×630px
+- ファイルを置くだけで `/ogp.png` として配信される（`RAILS_SERVE_STATIC_FILES=true` が render.yaml で設定済み）
+
+## 変更ファイル
+
+- `app/views/layouts/application.html.erb` — OGPタグ追加・titleを動的化
+- `app/controllers/prescriptions_controller.rb` — `@og_title`, `@og_description` セット
+- `app/controllers/side_effect_reports_controller.rb` — 同上
+- `app/views/prescriptions/show.html.erb` — Xシェアボタン追加
+- `app/views/side_effect_reports/show.html.erb` — Xシェアボタン追加
+- `app/assets/stylesheets/application.css` — `.btn-share-x`, `.x-icon` スタイル追加


### PR DESCRIPTION
## 概要

- XシェアボタンとLINEシェアボタンを服薬指導箋・副作用レポートの結果ページに追加
- OGPメタタグ（動的タイトル・説明文・静的画像）を実装
- 本番URLを `config/environments/production.rb` に登録

## 変更内容

### Xシェアボタン
- ツイート文
  - 服薬指導箋: `「{トピック名}」について柴犬薬剤師に相談してみた #Pharmacy_Bar`
  - 副作用レポート: `今日のことを柴犬薬剤師に相談したら副作用レポートが届いた #Pharmacy_Bar`
- シェアURLはトップページ固定（`root_url`）

### LINEシェアボタン
- `https://social-plugins.line.me/lineit/share?url=...` 形式
- シェアURLはトップページ固定（`root_url`）

### OGPメタタグ
| ページ | og:title | og:description |
|---|---|---|
| 服薬指導箋 | 「{topic.name}」への服薬指導箋 | ai_response の冒頭100文字 |
| 副作用レポート | 副作用レポート | ai_response の冒頭100文字 |
| その他 | 深夜薬局 Bar | デフォルト説明文 |

- `og:image` → `public/ogp.png`（静的）← **要対応: 画像ファイルを別途追加してください**
- `twitter:card` → `summary_large_image`

### 本番URL登録
- `config/environments/production.rb` に `routes.default_url_options` を追加
- URLヘルパーが rake タスク・コンソールでも正しく動作するようになります

## 注意

- `public/ogp.png` が未配置のため、OGP画像は404になります。1200×630px の画像を別途追加してください
- LINEシェアのプレビューはローカル（localhost）では確認不可。本番デプロイ後に確認してください

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)