### PR TITLE
Design: TOPページ全体デザイン改善・お題ヒント機能追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -568,6 +568,59 @@ body {
   font-weight: 500;
 }
 
+.topic-hint-wrap {
+  margin-top: 24px;
+  display: inline-block;
+  max-width: 72%;
+  position: relative;
+  transform: rotate(-0.6deg);
+}
+
+.topic-hint {
+  padding: 14px 16px 18px;
+  background: rgba(240, 230, 200, 0.06);
+  box-shadow: 2px 4px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.4);
+  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%);
+}
+
+.topic-hint-curl {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+}
+
+.topic-hint-curl svg {
+  display: block;
+}
+
+.hint-curl-shadow {
+  fill: rgba(0, 0, 0, 0.4);
+}
+
+.hint-curl-back {
+  fill: #3a3028;
+}
+
+.topic-hint-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: #a08858;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.topic-hint-body {
+  font-size: 14px;
+  color: #c8b07a;
+  line-height: 1.8;
+  white-space: pre-wrap;
+}
+
 /* ── chat input layout ── */
 .chat-input-row {
   display: flex;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -322,61 +322,53 @@ body {
   max-width: none;
 }
 
-/* ── お品書き ── */
+/* ── お品書き（ライトボックス + 手製紙） ── */
+@keyframes sign-glow {
+  0%, 85%   { box-shadow: 0 0 14px rgba(200,230,210,0.55), 0 0 40px rgba(180,220,195,0.25), 0 0 70px rgba(160,210,180,0.12), 0 6px 32px rgba(0,0,0,0.85); }
+  86%       { box-shadow: 0 0 3px rgba(200,230,210,0.12), 0 6px 32px rgba(0,0,0,0.85); }
+  87%       { box-shadow: 0 0 14px rgba(200,230,210,0.55), 0 0 40px rgba(180,220,195,0.25), 0 0 70px rgba(160,210,180,0.12), 0 6px 32px rgba(0,0,0,0.85); }
+  88%       { box-shadow: 0 0 5px rgba(200,230,210,0.18), 0 6px 32px rgba(0,0,0,0.85); }
+  90%       { box-shadow: 0 0 14px rgba(200,230,210,0.55), 0 0 40px rgba(180,220,195,0.25), 0 0 70px rgba(160,210,180,0.12), 0 6px 32px rgba(0,0,0,0.85); }
+  100%      { box-shadow: 0 0 14px rgba(200,230,210,0.55), 0 0 40px rgba(180,220,195,0.25), 0 0 70px rgba(160,210,180,0.12), 0 6px 32px rgba(0,0,0,0.85); }
+}
+
 .osinagaki-wrap {
   position: relative;
   display: inline-block;
-  transform: rotate(-1.4deg) skewX(-0.3deg);
   max-width: 440px;
   width: 100%;
 }
 
+.osinagaki-pole {
+  display: none;
+}
+
+/* ライトボックス本体 */
 .osinagaki {
-  background: #111a16;
-  border: 1px solid #3a6050;
-  border-radius: 3px 2px 4px 2px;
+  background: rgba(195, 225, 205, 0.28);
+  border: 2px solid rgba(200, 230, 210, 0.5);
+  border-radius: 4px;
   box-shadow:
-    inset 0 2px 12px rgba(0, 0, 0, 0.4),
-    3px 5px 28px rgba(0, 0, 0, 0.8),
-    -1px -1px 4px rgba(0, 0, 0, 0.4);
-  padding: 32px 40px;
-  text-align: left;
-  color: #c8e0d4;
+    0 0 14px rgba(200, 230, 210, 0.55),
+    0 0 40px rgba(180, 220, 195, 0.25),
+    0 0 70px rgba(160, 210, 180, 0.12),
+    0 6px 32px rgba(0, 0, 0, 0.85);
+  padding: 16px;
   position: relative;
-  clip-path: polygon(0 0, 100% 0, 100% calc(100% - 40px), calc(100% - 40px) 100%, 0 100%);
+  animation: sign-glow 9s ease-in-out infinite;
 }
 
-.osinagaki::before {
-  content: '';
-  position: absolute;
-  inset: 0;
+/* 手製紙：光を遮る暗い面、周囲16pxに光が漏れる */
+.osinagaki-paper {
   background:
-    linear-gradient(135deg, rgba(255,255,255,0.06) 0%, transparent 50%),
-    linear-gradient(to bottom, rgba(0,0,0,0.03) 0%, transparent 40%, rgba(0,0,0,0.05) 100%);
-  border-radius: inherit;
-  pointer-events: none;
-}
-
-.page-curl {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  width: 44px;
-  height: 44px;
-  pointer-events: none;
-  z-index: 10;
-}
-
-.page-curl svg {
-  display: block;
-}
-
-.curl-fold-shadow {
-  fill: rgba(0, 0, 0, 0.4);
-}
-
-.curl-back {
-  fill: #4a6058;
+    radial-gradient(ellipse 55% 45% at 22% 38%, rgba(10,14,12,0.28) 0%, transparent 70%),
+    radial-gradient(ellipse 42% 55% at 72% 65%, rgba(10,14,12,0.32) 0%, transparent 65%),
+    radial-gradient(ellipse 38% 35% at 58% 18%, rgba(10,14,12,0.2) 0%, transparent 60%),
+    radial-gradient(ellipse 30% 40% at 15% 80%, rgba(10,14,12,0.22) 0%, transparent 55%),
+    rgba(10, 14, 12, 0.42);
+  padding: 28px 36px;
+  transform: rotate(0.6deg) translate(3px, -2px);
+  color: #c8e0d4;
 }
 
 .osinagaki-header {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -275,7 +275,7 @@ body {
   font-family: 'Klee One', cursive;
   font-size: 15px;
   color: var(--text-muted);
-  margin-bottom: 40px;
+  margin-bottom: 56px;
   padding-bottom: 28px;
   border: none;
   border-image: linear-gradient(to right, transparent, var(--border) 25%, var(--border) 75%, transparent) 1;
@@ -288,7 +288,7 @@ body {
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 36px;
+  margin-bottom: 48px;
   justify-content: center;
 }
 
@@ -306,6 +306,30 @@ body {
   line-height: 1.8;
   color: var(--text-muted);
   text-align: left;
+}
+
+.greeting-supplement {
+  text-align: center;
+  margin-bottom: 52px;
+  opacity: 0.8;
+}
+
+.greeting-supplement p {
+  font-size: 15px;
+  line-height: 2;
+  color: #b8a888;
+}
+
+.greeting-supplement p + p {
+  margin-top: 20px;
+}
+
+.supplement-heading {
+  display: inline-block;
+  color: #fff5e0;
+  border-bottom: 1px solid rgba(255, 245, 224, 0.25);
+  padding-bottom: 2px;
+  margin-bottom: 4px;
 }
 
 .greeting-text strong {
@@ -443,6 +467,79 @@ body {
 
 .osinagaki-link:hover {
   opacity: 1;
+}
+
+/* ── メニューカード（2枚横並び） ── */
+.menu-cards {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.menu-card {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  width: 192px;
+  transition: transform 0.15s, opacity 0.15s;
+}
+
+.menu-card:hover {
+  transform: translateY(-2px);
+  opacity: 0.9;
+}
+
+.menu-card-light {
+  background: rgba(195, 225, 205, 0.28);
+  border: 2px solid rgba(200, 230, 210, 0.5);
+  border-radius: 4px;
+  box-shadow:
+    0 0 10px rgba(200, 230, 210, 0.45),
+    0 0 28px rgba(180, 220, 195, 0.2),
+    0 4px 20px rgba(0, 0, 0, 0.75);
+  padding: 10px;
+  animation: sign-glow 9s ease-in-out infinite;
+}
+
+.menu-card-light--alt {
+  animation-delay: 1.5s;
+}
+
+.menu-card-paper {
+  background:
+    radial-gradient(ellipse 60% 50% at 30% 35%, rgba(10,14,12,0.25) 0%, transparent 70%),
+    radial-gradient(ellipse 45% 55% at 70% 70%, rgba(10,14,12,0.3) 0%, transparent 65%),
+    rgba(10, 14, 12, 0.42);
+  padding: 28px 20px 24px;
+  text-align: center;
+  transform: rotate(0.5deg) translate(2px, -1px);
+}
+
+.menu-card-paper--alt {
+  transform: rotate(-0.7deg) translate(-1px, -2px);
+}
+
+.menu-card-icon {
+  width: 44px;
+  height: 44px;
+  color: #7aaa96;
+  margin-bottom: 14px;
+}
+
+.menu-card-name {
+  font-family: 'New Tegomin', serif;
+  font-size: 17px;
+  font-weight: 400;
+  color: #e0f0e8;
+  margin-bottom: 6px;
+  line-height: 1.5;
+}
+
+.menu-card-sub {
+  font-size: 12px;
+  color: var(--text-label);
+  letter-spacing: 0.08em;
 }
 
 .feature-cards {

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -14,38 +14,32 @@
 
   <div class="osinagaki-wrap">
     <div class="osinagaki">
-      <p class="osinagaki-header">本日のご案内</p>
+      <div class="osinagaki-paper">
+        <p class="osinagaki-header">本日のご案内</p>
 
-      <div class="osinagaki-divider"></div>
+        <div class="osinagaki-divider"></div>
 
-      <%= link_to play_path, class: "osinagaki-item" do %>
-        <div class="osinagaki-item-header">
-          <%= inline_svg "feature1-notes.svg", css_class: "osinagaki-icon" %>
-          <h2 class="osinagaki-name">服薬指導箋</h2>
-        </div>
-        <p class="osinagaki-desc">お題にお答えいただくと、柴犬薬剤師がお薬と服薬指導箋をご用意いたします。</p>
-        <p class="osinagaki-link">指導箋を受け取る →</p>
-      <% end %>
+        <%= link_to play_path, class: "osinagaki-item" do %>
+          <div class="osinagaki-item-header">
+            <%= inline_svg "feature1-notes.svg", css_class: "osinagaki-icon" %>
+            <h2 class="osinagaki-name">服薬指導箋</h2>
+          </div>
+          <p class="osinagaki-desc">お題にお答えいただくと、柴犬薬剤師がお薬と服薬指導箋をご用意いたします。</p>
+          <p class="osinagaki-link">指導箋を受け取る →</p>
+        <% end %>
 
-      <div class="osinagaki-divider"></div>
+        <div class="osinagaki-divider"></div>
 
-      <%= link_to new_side_effect_path, class: "osinagaki-item" do %>
-        <div class="osinagaki-item-header">
-          <%= inline_svg "feature2-diary.svg", css_class: "osinagaki-icon" %>
-          <h2 class="osinagaki-name">今日の副作用レポート</h2>
-        </div>
-        <p class="osinagaki-desc">今日のお困りごとをお聞かせください。副作用レポートを発行いたします。</p>
-        <p class="osinagaki-link">レポートを発行する →</p>
-      <% end %>
+        <%= link_to new_side_effect_path, class: "osinagaki-item" do %>
+          <div class="osinagaki-item-header">
+            <%= inline_svg "feature2-diary.svg", css_class: "osinagaki-icon" %>
+            <h2 class="osinagaki-name">今日の副作用レポート</h2>
+          </div>
+          <p class="osinagaki-desc">今日のお困りごとをお聞かせください。副作用レポートを発行いたします。</p>
+          <p class="osinagaki-link">レポートを発行する →</p>
+        <% end %>
+      </div>
     </div>
-
-    <span class="page-curl" aria-hidden="true">
-      <svg width="44" height="44" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg">
-        <!-- 折れ目の影（カード面に落ちる） -->
-        <polygon points="6,44 44,6 6,6" class="curl-fold-shadow"/>
-        <!-- 折り返した紙片（カード面に重なる） -->
-        <polygon points="8,44 44,8 8,8" class="curl-back"/>
-      </svg>
-    </span>
+    <div class="osinagaki-pole" aria-hidden="true"></div>
   </div>
 </div>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -12,34 +12,38 @@
     </p>
   </div>
 
-  <div class="osinagaki-wrap">
-    <div class="osinagaki">
-      <div class="osinagaki-paper">
-        <p class="osinagaki-header">本日のご案内</p>
+  <div class="greeting-supplement">
+    <p>
+      <span class="supplement-heading">【服薬指導箋】知識のお題が出ます。正解じゃなくていい——</span><br>
+      今の自分の言葉で答えてみてください。<br>
+      柴犬薬剤師が回答を分析し、処方箋を仕上げます。
+    </p>
+    <p>
+      <span class="supplement-heading">【副作用レポート】今日やったこと、感じたことをそのまま話してください。</span><br>
+      どんな一日も、ちゃんと薬になります。<br>
+      今夜のお酒と副作用レポートを処方します。
+    </p>
+  </div>
 
-        <div class="osinagaki-divider"></div>
-
-        <%= link_to play_path, class: "osinagaki-item" do %>
-          <div class="osinagaki-item-header">
-            <%= inline_svg "feature1-notes.svg", css_class: "osinagaki-icon" %>
-            <h2 class="osinagaki-name">服薬指導箋</h2>
-          </div>
-          <p class="osinagaki-desc">お題にお答えいただくと、柴犬薬剤師がお薬と服薬指導箋をご用意いたします。</p>
-          <p class="osinagaki-link">指導箋を受け取る →</p>
-        <% end %>
-
-        <div class="osinagaki-divider"></div>
-
-        <%= link_to new_side_effect_path, class: "osinagaki-item" do %>
-          <div class="osinagaki-item-header">
-            <%= inline_svg "feature2-diary.svg", css_class: "osinagaki-icon" %>
-            <h2 class="osinagaki-name">今日の副作用レポート</h2>
-          </div>
-          <p class="osinagaki-desc">今日のお困りごとをお聞かせください。副作用レポートを発行いたします。</p>
-          <p class="osinagaki-link">レポートを発行する →</p>
-        <% end %>
+  <div class="menu-cards">
+    <%= link_to play_path, class: "menu-card" do %>
+      <div class="menu-card-light">
+        <div class="menu-card-paper">
+          <%= inline_svg "feature1-notes.svg", css_class: "menu-card-icon" %>
+          <h2 class="menu-card-name">服薬指導箋</h2>
+          <p class="menu-card-sub">お題に答える</p>
+        </div>
       </div>
-    </div>
-    <div class="osinagaki-pole" aria-hidden="true"></div>
+    <% end %>
+
+    <%= link_to new_side_effect_path, class: "menu-card" do %>
+      <div class="menu-card-light menu-card-light--alt">
+        <div class="menu-card-paper menu-card-paper--alt">
+          <%= inline_svg "feature2-diary.svg", css_class: "menu-card-icon" %>
+          <h2 class="menu-card-name">副作用レポート</h2>
+          <p class="menu-card-sub">今日を振り返る</p>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -13,6 +13,20 @@
       <h1 class="topic-name"><%= @topic.name %></h1>
       <p class="topic-rule"><%= @topic.rule %></p>
       <p class="topic-question"><%= @topic.question %></p>
+      <% if @topic.hint.present? %>
+        <div class="topic-hint-wrap">
+          <div class="topic-hint">
+            <span class="topic-hint-label">📎 前提知識</span>
+            <p class="topic-hint-body"><%= @topic.hint %></p>
+          </div>
+          <span class="topic-hint-curl" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <polygon points="3,24 24,3 3,3" class="hint-curl-shadow"/>
+              <polygon points="4,24 24,4 4,4" class="hint-curl-back"/>
+            </svg>
+          </span>
+        </div>
+      <% end %>
     </section>
     <div class="topic-divider"></div>
 

--- a/db/migrate/20260509000420_add_hint_to_topics.rb
+++ b/db/migrate/20260509000420_add_hint_to_topics.rb
@@ -1,0 +1,5 @@
+class AddHintToTopics < ActiveRecord::Migration[7.0]
+  def change
+    add_column :topics, :hint, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_02_173651) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_09_000420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_02_173651) do
     t.string "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "hint"
   end
 
 end

--- a/lib/tasks/generate_hints.rb
+++ b/lib/tasks/generate_hints.rb
@@ -1,0 +1,37 @@
+client = Anthropic::Client.new(api_key: ENV["CLAUDE_API_KEY"])
+
+HINT_PROMPT = <<~PROMPT
+  あなたはクイズの前提知識を書くライターです。
+  お題の名前・カテゴリ・ルール・問いを受け取り、答えを考えるための「とっかかり」となる前提知識を書いてください。
+
+  ## ルール
+  - 2〜3文、合計100文字以内
+  - 答えそのものは書かない
+  - 専門用語が出る場合は一言補足する
+  - 「〜です」調で書く
+  - フォーマットはテキストのみ（箇条書き・記号不要）
+PROMPT
+
+Topic.find_each do |topic|
+  next if topic.hint.present?
+
+  user_content = <<~TEXT
+    カテゴリ：#{topic.category}
+    お題：#{topic.name}
+    ルール：#{topic.rule}
+    問い：#{topic.question}
+  TEXT
+
+  response = client.messages.create(
+    model: :"claude-haiku-4-5-20251001",
+    max_tokens: 256,
+    system_: [{ type: "text", text: HINT_PROMPT }],
+    messages: [{ role: "user", content: user_content }]
+  )
+
+  hint = response.content.find { |block| block.type == :text }&.text&.strip
+  topic.update!(hint: hint)
+  puts "✓ [#{topic.id}] #{topic.name}\n  → #{hint}\n"
+end
+
+puts "\n完了: #{Topic.where.not(hint: nil).count}/#{Topic.count} 件"


### PR DESCRIPTION
## Summary

- **お題ヒント機能**: `topics.hint` カラムを追加し、Claude で全21件の前提知識を自動生成。付箋スタイル（clip-path折り目 + SVGカール）で表示
- **TOPページ看板**: お品書きをペラ紙スタイルから蛍光灯ライトボックス + 手製紙の2層構造に変更。昭和レトロなグリーン系グロウが点滅
- **TOPページレイアウト**: お品書きを2カード横並びに変更し、挨拶下に各機能の説明文を追加。タイトル→挨拶→説明→メニューの余白を整理

## Test plan

- [x] `/play` でお題が表示され、前提知識（付箋）が表示される
- [x] ヒントがないお題では付箋が表示されない
- [x] TOPページ (`/`) のライトボックスがグロウ点滅する
- [x] 2カードのリンクがそれぞれ正しいページに遷移する
- [x] モバイルで2カードが縦並びになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)